### PR TITLE
Add support for updating households

### DIFF
--- a/api-spec/openapi.yml
+++ b/api-spec/openapi.yml
@@ -123,6 +123,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - households
+      summary: update a household by id
+      description: update a household by id
+      operationId: updateUserHousehold
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchableHousehold'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Household'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     BaseUser:
@@ -186,11 +216,11 @@ components:
         joined_at:
           type: string
           format: date-time
-    Household:
+    BaseHousehold:
       type: object
+      additionalProperties: false
       required:
         - id
-        - name
         - created_at
         - created_by
         - updated_at
@@ -216,6 +246,17 @@ components:
           readOnly: true
           items:
             $ref: '#/components/schemas/HouseholdMember'
+    Household:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseHousehold'
+      required:
+        - name
+    PatchableHousehold:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseHousehold'
+      minProperties: 1
     Error:
       type: object
       properties:

--- a/src/routes/user-households-router.ts
+++ b/src/routes/user-households-router.ts
@@ -45,5 +45,25 @@ router.delete('/:id', async (request, response, next) => {
     next(createError(401, 'Invalid credentials'));
   }
 });
+router.patch('/:id', async (request, response, next) => {
+  const userId = request.auth?.payload.sub;
+  if (userId) {
+    const householdService = new UserHouseholdsService(userId);
+    try {
+      const updatedHousehold = await householdService.updateHousehold(Number(request.params.id), request.body);
+      response.status(200).json(updatedHousehold);
+    } catch (error) {
+      if (error instanceof DuplicateEntityError) {
+        next(createError(409, error.message));
+      } else if (error instanceof Error) {
+        next(createError(500, error.message));
+      } else {
+        next(createError(500, 'An unknown error occurred.'));
+      }
+    }
+  } else {
+    next(createError(401, 'Invalid credentials'));
+  }
+});
 
 export default router;

--- a/src/user-households/user-households-service.db.test.ts
+++ b/src/user-households/user-households-service.db.test.ts
@@ -64,4 +64,26 @@ describe('user households service', () => {
     await serviceA.deleteHousehold(id);
     expect(await serviceA.getUserHouseholds()).toEqual([]);
   });
+  it('should be possible to update an existing household created by the user making the request', async () => {
+    const household = await serviceA.createHousehold({ name: 'A' });
+    const updatedHousehold = await serviceA.updateHousehold(household.id, { name: 'B' });
+    expect(updatedHousehold).toEqual({ ...household, name: 'B' });
+    expect(await serviceA.getUserHouseholds()).toEqual([expect.objectContaining({ name: 'B' })]);
+  });
+  it('should not be possible to update a household created by another user', async () => {
+    const household = await serviceA.createHousehold({ name: 'A' });
+    await serviceB.updateHousehold(household.id, { name: 'B' });
+    expect(await serviceA.getUserHouseholds()).toEqual([expect.objectContaining({ name: 'A' })]);
+  });
+  it('should not be possible to update a household to have the same name as an existing household', async () => {
+    await serviceA.createHousehold({ name: 'A' });
+    const household = await serviceA.createHousehold({ name: 'B' });
+    await expect((async () => await serviceA.updateHousehold(household.id, { name: 'A' }))()).rejects.toThrowError(
+      'Household with name A already exists',
+    );
+    expect(await serviceA.getUserHouseholds()).toEqual([
+      expect.objectContaining({ name: 'B' }),
+      expect.objectContaining({ name: 'A' }),
+    ]);
+  });
 });

--- a/src/user-households/user-households-service.ts
+++ b/src/user-households/user-households-service.ts
@@ -1,5 +1,10 @@
+import type { PostgrestError } from '@supabase/supabase-js';
 import { DATABASE_ERROR_CODES, DuplicateEntityError } from '../db-error-handling/supabase-errors.js';
 import { getSupabaseClient } from '../lib/supabase.js';
+
+export type Household = {
+  name: string;
+};
 
 export class UserHouseholdsService {
   private readonly supabase;
@@ -8,19 +13,31 @@ export class UserHouseholdsService {
     this.supabase = getSupabaseClient(user);
   }
 
-  async createHousehold(household: { name: string }) {
+  async createHousehold(household: Household) {
     const { data, error } = await this.supabase.from('households').insert(household).select();
     if (error) {
-      if (error.code === DATABASE_ERROR_CODES.UNIQUE_VIOLATION) {
-        throw new DuplicateEntityError(`Household with name ${household.name} already exists`);
-      }
-      throw error;
+      throw this.handleSupabaseError(error, household);
     }
     return data[0];
   }
 
   async deleteHousehold(id: number) {
     await this.supabase.from('households').delete().eq('id', id);
+  }
+
+  async updateHousehold(id: number, household: Household) {
+    const { data, error } = await this.supabase.from('households').update(household).eq('id', id).select();
+    if (error) {
+      throw this.handleSupabaseError(error, household);
+    }
+    return data[0];
+  }
+
+  handleSupabaseError(error: PostgrestError, household: Household) {
+    if (error.code === DATABASE_ERROR_CODES.UNIQUE_VIOLATION) {
+      return new DuplicateEntityError(`Household with name ${household.name} already exists`);
+    }
+    return error;
   }
 
   async getUserHouseholds() {

--- a/src/user-households/user-households.test.ts
+++ b/src/user-households/user-households.test.ts
@@ -12,12 +12,14 @@ vi.mock('express-oauth2-jwt-bearer', async (importOriginal) => ({
 const getUserHouseholdsMock = vi.hoisted(() => vi.fn());
 const createUserHouseholdMock = vi.hoisted(() => vi.fn());
 const deleteUserHouseholdMock = vi.hoisted(() => vi.fn());
+const updateUserHouseholdMock = vi.hoisted(() => vi.fn());
 vi.mock('./user-households-service.js', () => {
   const UserHouseholdsService = vi.fn(
     class {
       getUserHouseholds = getUserHouseholdsMock;
       createHousehold = createUserHouseholdMock;
       deleteHousehold = deleteUserHouseholdMock;
+      updateHousehold = updateUserHouseholdMock;
     },
   );
   return { UserHouseholdsService };
@@ -56,6 +58,16 @@ describe('user households routes', () => {
     describe('deleteHousehold', () => {
       it('should throw an error if the user ID has not been set in the request', async () => {
         const response = await request(app).delete('/api/v1/households/1').send();
+
+        expect(response.body).toEqual({
+          status: 401,
+          message: 'Invalid credentials',
+        });
+      });
+    });
+    describe('updateHousehold', () => {
+      it('should throw an error if the user ID has not been set in the request', async () => {
+        const response = await request(app).patch('/api/v1/households/1').send({ name: 'David' });
 
         expect(response.body).toEqual({
           status: 401,
@@ -152,6 +164,121 @@ describe('user households routes', () => {
         expect(UserHouseholdsService).toHaveBeenCalledWith('UserID');
         expect(deleteUserHouseholdMock).toHaveBeenCalledWith(1);
         expect(response.status).toEqual(204);
+      });
+    });
+    describe('updateHousehold', () => {
+      it('should return the updated household', async () => {
+        updateUserHouseholdMock.mockResolvedValue({
+          id: 1,
+          name: 'Dave',
+          created_by: '',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        });
+        const response = await request(app).patch('/api/v1/households/1').send({ name: 'Dave' });
+
+        expect(UserHouseholdsService).toHaveBeenCalledWith('UserID');
+        expect(updateUserHouseholdMock).toHaveBeenCalledWith(1, { name: 'Dave' });
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual({
+          id: 1,
+          name: 'Dave',
+          created_by: '',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        });
+      });
+      it('should return a 409 status code when updating name to match an existing household', async () => {
+        updateUserHouseholdMock.mockRejectedValue(new DuplicateEntityError());
+        const response = await request(app).patch('/api/v1/households/1').send({ name: 'Dave' });
+        expect(response.status).toEqual(409);
+        expect(response.body).toEqual({ status: 409, message: 'Duplicate entity' });
+      });
+      it('should return a 500 status code when an error occurs', async () => {
+        updateUserHouseholdMock.mockRejectedValue(new Error('Message'));
+        const response = await request(app).patch('/api/v1/households/1').send({ name: 'Dave' });
+        expect(response.status).toEqual(500);
+        expect(response.body).toEqual({ status: 500, message: 'Message' });
+      });
+      it('should return a 500 status code when an unknown error occurs', async () => {
+        updateUserHouseholdMock.mockRejectedValue({});
+        const response = await request(app).patch('/api/v1/households/1').send({ name: 'Dave' });
+        expect(response.status).toEqual(500);
+        expect(response.body).toEqual({ status: 500, message: 'An unknown error occurred.' });
+      });
+      it('should return a 400 status code when id is included in the request body', async () => {
+        const response = await request(app).patch('/api/v1/households/1').send({ name: 'Dave', id: 123 });
+        expect(response.status).toEqual(400);
+        expect(response.body).toEqual({
+          errors: [
+            {
+              errorCode: 'readOnly.openapi.validation',
+              message: 'is read-only',
+              path: '/body/id',
+            },
+          ],
+          message: 'request/body/id is read-only',
+          name: 'Bad Request',
+          path: '/api/v1/households/1',
+          status: 400,
+        });
+      });
+      it('should return a 400 status code when created_at is included in the request body', async () => {
+        const response = await request(app)
+          .patch('/api/v1/households/1')
+          .send({ name: 'Dave', created_at: '2025-12-03T20:06:30.617804+00:00' });
+        expect(response.status).toEqual(400);
+        expect(response.body).toEqual({
+          errors: [
+            {
+              errorCode: 'readOnly.openapi.validation',
+              message: 'is read-only',
+              path: '/body/created_at',
+            },
+          ],
+          message: 'request/body/created_at is read-only',
+          name: 'Bad Request',
+          path: '/api/v1/households/1',
+          status: 400,
+        });
+      });
+      it('should return a 400 status code when created_by is included in the request body', async () => {
+        const response = await request(app)
+          .patch('/api/v1/households/1')
+          .send({ name: 'Dave', created_by: '2025-12-03T20:06:30.617804+00:00' });
+        expect(response.status).toEqual(400);
+        expect(response.body).toEqual({
+          errors: [
+            {
+              errorCode: 'readOnly.openapi.validation',
+              message: 'is read-only',
+              path: '/body/created_by',
+            },
+          ],
+          message: 'request/body/created_by is read-only',
+          name: 'Bad Request',
+          path: '/api/v1/households/1',
+          status: 400,
+        });
+      });
+      it('should return a 400 status code when updated_at is included in the request body', async () => {
+        const response = await request(app)
+          .patch('/api/v1/households/1')
+          .send({ name: 'Dave', updated_at: '2025-12-03T20:06:30.617804+00:00' });
+        expect(response.status).toEqual(400);
+        expect(response.body).toEqual({
+          errors: [
+            {
+              errorCode: 'readOnly.openapi.validation',
+              message: 'is read-only',
+              path: '/body/updated_at',
+            },
+          ],
+          message: 'request/body/updated_at is read-only',
+          name: 'Bad Request',
+          path: '/api/v1/households/1',
+          status: 400,
+        });
       });
     });
   });

--- a/supabase/migrations/20251201010007_create_households_table.sql
+++ b/supabase/migrations/20251201010007_create_households_table.sql
@@ -32,3 +32,10 @@ CREATE POLICY "Users can delete own households" ON "user-service".households
     USING (
     (SELECT auth.jwt() ->> 'sub') = created_by
     );
+
+DROP POLICY IF EXISTS "Users can update own households" ON "user-service".households;
+CREATE POLICY "Users can update own households" ON "user-service".households
+    FOR UPDATE TO public
+    USING (
+    (SELECT auth.jwt() ->> 'sub') = created_by
+    );


### PR DESCRIPTION
- Introduce `PATCH /households/:id` API endpoint for updating household details.
- Update OpenAPI specification to document the new endpoint and schemas.
- Implement `updateHousehold` method in service with error handling for duplicates and validation.
- Add policies to allow users to update their own households.
- Enhance test coverage for update scenarios, including edge cases.