### PR TITLE
Add user invitation support for households

### DIFF
--- a/api-spec/openapi.yml
+++ b/api-spec/openapi.yml
@@ -153,6 +153,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /households/{id}/invitations:
+    post:
+      tags:
+        - households
+      summary: invite a user to join a household
+      description: invite a user to join a household
+      operationId: inviteUserToHousehold
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/HouseholdInvitation'
+      responses:
+        201:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HouseholdInvitation'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     BaseUser:
@@ -257,6 +292,31 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseHousehold'
       minProperties: 1
+    HouseholdInvitation:
+      type: object
+      required:
+        - id
+        - household_id
+        - invited_by_user_id
+        - invited_user
+        - invited_at
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        household_id:
+          type: integer
+          readOnly: true
+        invited_by_user_id:
+          type: string
+          readOnly: true
+        invited_user:
+          type: string
+          format: email
+        invited_at:
+          type: string
+          format: date-time
+          readOnly: true
     Error:
       type: object
       properties:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:db": "vitest run --project db",
     "check": "biome check",
     "format": "biome check --write --unsafe",
-    "gen-types": "supabase gen types typescript --project-id=xlzyfsfxuvxlbdrstnec --schema=user-service > src/types/database.types.ts"
+    "types": "supabase gen types typescript --project-id=xlzyfsfxuvxlbdrstnec --schema=user_service > src/types/database.types.ts",
+    "posttypes": "npm run format"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.86.0",

--- a/src/db-error-handling/supabase-errors.ts
+++ b/src/db-error-handling/supabase-errors.ts
@@ -7,3 +7,15 @@ export class DuplicateEntityError extends Error {
     super(message);
   }
 }
+
+export class InvitedUserIsOwnerError extends Error {
+  constructor(message = 'The invited user is already the owner of the household') {
+    super(message);
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(message = 'The requested entity was not found') {
+    super(message);
+  }
+}

--- a/src/lib/supabase.test.ts
+++ b/src/lib/supabase.test.ts
@@ -47,7 +47,7 @@ describe('database connection', () => {
     expect(createClient).toHaveBeenCalledWith(
       'SUPABASE_URL',
       'SUPABASE_ANON_KEY',
-      expect.objectContaining({ db: { schema: 'user-service' } }),
+      expect.objectContaining({ db: { schema: 'user_service' } }),
     );
   });
 });

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -28,7 +28,7 @@ export function getSupabaseClient(user: string): SupabaseClient<Database> {
   }
   supabaseClient = createClient<Database>(supabaseUrl, supabaseKey, {
     accessToken: () => signJwt(user, supabaseSigningKey),
-    db: { schema: 'user-service' },
+    db: { schema: 'user_service' },
   });
 
   return supabaseClient;

--- a/src/routes/user-households-router.ts
+++ b/src/routes/user-households-router.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express';
 import createError from 'http-errors';
-import { DuplicateEntityError } from '../db-error-handling/supabase-errors.js';
-import { UserHouseholdsService } from '../user-households/user-households-service.js';
+import { DuplicateEntityError, InvitedUserIsOwnerError, NotFoundError } from '../db-error-handling/supabase-errors.js';
+import { type HouseholdInvitation, UserHouseholdsService } from '../user-households/user-households-service.js';
 
 const router = Router();
 
 router.get('/', async (request, response, next) => {
-  const userId = request.auth?.payload.sub;
+  const userId = request.auth?.payload.email as string;
   if (userId) {
     const householdService = new UserHouseholdsService(userId);
     const households = await householdService.getUserHouseholds();
@@ -16,7 +16,7 @@ router.get('/', async (request, response, next) => {
   }
 });
 router.post('/', async (request, response, next) => {
-  const userId = request.auth?.payload.sub;
+  const userId = request.auth?.payload.email as string;
   if (userId) {
     const householdService = new UserHouseholdsService(userId);
     try {
@@ -36,7 +36,7 @@ router.post('/', async (request, response, next) => {
   }
 });
 router.delete('/:id', async (request, response, next) => {
-  const userId = request.auth?.payload.sub;
+  const userId = request.auth?.payload.email as string;
   if (userId) {
     const householdService = new UserHouseholdsService(userId);
     await householdService.deleteHousehold(Number(request.params.id));
@@ -46,7 +46,7 @@ router.delete('/:id', async (request, response, next) => {
   }
 });
 router.patch('/:id', async (request, response, next) => {
-  const userId = request.auth?.payload.sub;
+  const userId = request.auth?.payload.email as string;
   if (userId) {
     const householdService = new UserHouseholdsService(userId);
     try {
@@ -55,6 +55,8 @@ router.patch('/:id', async (request, response, next) => {
     } catch (error) {
       if (error instanceof DuplicateEntityError) {
         next(createError(409, error.message));
+      } else if (error instanceof NotFoundError) {
+        next(createError(404, error.message));
       } else if (error instanceof Error) {
         next(createError(500, error.message));
       } else {
@@ -65,5 +67,32 @@ router.patch('/:id', async (request, response, next) => {
     next(createError(401, 'Invalid credentials'));
   }
 });
-
+router.post('/:id/invitations', async (request, response, next) => {
+  const userId = request.auth?.payload.email as string;
+  if (userId) {
+    const invitedUserEmails = new Set<string>(request.body.map((invite: HouseholdInvitation) => invite.invited_user));
+    if (invitedUserEmails.size === request.body.length) {
+      const householdService = new UserHouseholdsService(userId);
+      try {
+        const createdInvitations = await householdService.inviteUsers(
+          Number(request.params.id),
+          Array.from(invitedUserEmails),
+        );
+        response.status(201).json(createdInvitations);
+      } catch (error) {
+        if (error instanceof InvitedUserIsOwnerError) {
+          next(createError(400, error.message));
+        } else if (error instanceof Error) {
+          next(createError(500, error.message));
+        } else {
+          next(createError(500, 'An unknown error occurred.'));
+        }
+      }
+    } else {
+      next(createError(400, 'Request body includes the same email address multiple times'));
+    }
+  } else {
+    next(createError(401, 'Invalid credentials'));
+  }
+});
 export default router;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -6,8 +6,40 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: '13.0.5';
   };
-  'user-service': {
+  user_service: {
     Tables: {
+      household_invitations: {
+        Row: {
+          household_id: number;
+          id: number;
+          invited_at: string | null;
+          invited_by_user_id: string;
+          invited_user: string;
+        };
+        Insert: {
+          household_id: number;
+          id?: number;
+          invited_at?: string | null;
+          invited_by_user_id?: string;
+          invited_user: string;
+        };
+        Update: {
+          household_id?: number;
+          id?: number;
+          invited_at?: string | null;
+          invited_by_user_id?: string;
+          invited_user?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'household_invitations_household_id_fkey';
+            columns: ['household_id'];
+            isOneToOne: false;
+            referencedRelation: 'households';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       households: {
         Row: {
           created_at: string | null;
@@ -158,7 +190,7 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
-  'user-service': {
+  user_service: {
     Enums: {},
   },
 } as const;

--- a/supabase/migrations/20251201005834_create_schema.sql
+++ b/supabase/migrations/20251201005834_create_schema.sql
@@ -1,8 +1,8 @@
-CREATE SCHEMA "user-service";
-GRANT USAGE ON SCHEMA "user-service" TO anon, authenticated, service_role;
-GRANT ALL ON ALL TABLES IN SCHEMA "user-service" TO anon, authenticated, service_role;
-GRANT ALL ON ALL ROUTINES IN SCHEMA "user-service" TO anon, authenticated, service_role;
-GRANT ALL ON ALL SEQUENCES IN SCHEMA "user-service" TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "user-service" GRANT ALL ON TABLES TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "user-service" GRANT ALL ON ROUTINES TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA "user-service" GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+CREATE SCHEMA user_service;
+GRANT USAGE ON SCHEMA user_service TO anon, authenticated, service_role;
+GRANT ALL ON ALL TABLES IN SCHEMA user_service TO anon, authenticated, service_role;
+GRANT ALL ON ALL ROUTINES IN SCHEMA user_service TO anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA user_service TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA user_service GRANT ALL ON TABLES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA user_service GRANT ALL ON ROUTINES TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA user_service GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;

--- a/supabase/migrations/20251201010007_create_households_table.sql
+++ b/supabase/migrations/20251201010007_create_households_table.sql
@@ -1,41 +1,41 @@
-CREATE TABLE IF NOT EXISTS "user-service".households
+CREATE TABLE IF NOT EXISTS user_service.households
 (
     id         SERIAL PRIMARY KEY,
     name       TEXT NOT NULL,
-    created_by TEXT NOT NULL DEFAULT (auth.jwt() ->> 'sub'),
+    created_by TEXT NOT NULL            DEFAULT (auth.jwt() ->> 'sub'),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    UNIQUE(name, created_by)
+    UNIQUE (name, created_by)
 );
-CREATE INDEX IF NOT EXISTS idx_households_created_by ON "user-service".households (created_by);
+CREATE INDEX IF NOT EXISTS idx_households_created_by ON user_service.households (created_by);
 
-ALTER TABLE "user-service".households
+ALTER TABLE user_service.households
     ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "Users can view own households" ON "user-service".households;
-CREATE POLICY "Users can view own households" ON "user-service".households
+DROP POLICY IF EXISTS "Users can view own households" ON user_service.households;
+CREATE POLICY "Users can view own households" ON user_service.households
     FOR SELECT TO public
     USING (
-    (SELECT auth.jwt() ->> 'sub') = created_by
+        (SELECT auth.jwt() ->> 'sub') = created_by
     );
 
-DROP POLICY IF EXISTS "Users can create households" ON "user-service".households;
-CREATE POLICY "Users can create households" ON "user-service".households
+DROP POLICY IF EXISTS "Users can create households" ON user_service.households;
+CREATE POLICY "Users can create households" ON user_service.households
     FOR INSERT TO public
     WITH CHECK (
-    (SELECT auth.jwt() ->> 'sub') = created_by
+        (SELECT auth.jwt() ->> 'sub') = created_by
     );
 
-DROP POLICY IF EXISTS "Users can delete own households" ON "user-service".households;
-CREATE POLICY "Users can delete own households" ON "user-service".households
+DROP POLICY IF EXISTS "Users can delete own households" ON user_service.households;
+CREATE POLICY "Users can delete own households" ON user_service.households
     FOR DELETE TO public
     USING (
-    (SELECT auth.jwt() ->> 'sub') = created_by
+        (SELECT auth.jwt() ->> 'sub') = created_by
     );
 
-DROP POLICY IF EXISTS "Users can update own households" ON "user-service".households;
-CREATE POLICY "Users can update own households" ON "user-service".households
+DROP POLICY IF EXISTS "Users can update own households" ON user_service.households;
+CREATE POLICY "Users can update own households" ON user_service.households
     FOR UPDATE TO public
     USING (
-    (SELECT auth.jwt() ->> 'sub') = created_by
+        (SELECT auth.jwt() ->> 'sub') = created_by
     );

--- a/supabase/migrations/20251203214308_create_household_invitations_table.sql
+++ b/supabase/migrations/20251203214308_create_household_invitations_table.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS user_service.household_invitations
+(
+    id                 SERIAL PRIMARY KEY,
+    household_id       INTEGER NOT NULL REFERENCES user_service.households (id) ON DELETE CASCADE,
+    invited_by_user_id TEXT    NOT NULL         DEFAULT (auth.jwt() ->> 'sub'),
+    invited_user       TEXT    NOT NULL,
+    invited_at         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (household_id, invited_user)
+);
+CREATE INDEX IF NOT EXISTS idx_household_invitations_email ON user_service.household_invitations (invited_user);
+CREATE INDEX IF NOT EXISTS idx_household_invitations_household_id ON user_service.household_invitations (household_id);
+
+ALTER TABLE user_service.household_invitations
+    ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own invitations" ON user_service.household_invitations;
+CREATE POLICY "Users can view own invitations" ON user_service.household_invitations
+    FOR SELECT TO public
+    USING (
+    true
+    );
+
+DROP POLICY IF EXISTS "Users can create invitations for households they own" ON user_service.household_invitations;
+CREATE POLICY "Users can create invitations for households they own" ON user_service.household_invitations
+    FOR INSERT TO public
+    WITH CHECK (
+    (SELECT auth.jwt() ->> 'sub') = (SELECT created_by
+                                     from user_service.households
+                                     WHERE id = household_id)
+    );
+
+DROP POLICY IF EXISTS "Users can delete own invitations" ON user_service.household_invitations;
+CREATE POLICY "Users can delete own invitations" ON user_service.household_invitations
+    FOR DELETE TO public
+    USING (
+    true
+    );
+
+DROP POLICY IF EXISTS "Users can update own invitations" ON user_service.household_invitations;
+CREATE POLICY "Users can update own invitations" ON user_service.household_invitations
+    FOR UPDATE TO public
+    USING (
+    true
+    );


### PR DESCRIPTION
- Introduce `POST /households/:id/invitations` API endpoint for inviting users to households.
- Update OpenAPI specification to document the new endpoint and schemas.
- Implement `inviteUsers` method in service with validation and error handling.
- Add checks for duplicate emails, invalid emails, and ownership conflicts during invitations.
- Add schema, table, and policies for `household_invitations` in the database.
- Migrate database schema name from `user-service` to `user_service`.
- Enhance test coverage, including edge cases for invitations and household updates.
- Update Supabase type generation script and related config.