### PR TITLE
Add pending invites to household responses and handle duplicate invitation errors

### DIFF
--- a/api-spec/openapi.yml
+++ b/api-spec/openapi.yml
@@ -259,6 +259,7 @@ components:
         - created_at
         - created_by
         - updated_at
+        - pending_invites
       properties:
         id:
           type: integer
@@ -276,6 +277,11 @@ components:
           type: string
           format: date-time
           readOnly: true
+        pending_invites:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/HouseholdInvitation'
         members:
           type: array
           readOnly: true

--- a/src/routes/user-households-router.ts
+++ b/src/routes/user-households-router.ts
@@ -82,6 +82,8 @@ router.post('/:id/invitations', async (request, response, next) => {
       } catch (error) {
         if (error instanceof InvitedUserIsOwnerError) {
           next(createError(400, error.message));
+        } else if (error instanceof DuplicateEntityError) {
+          next(createError(409, error.message));
         } else if (error instanceof Error) {
           next(createError(500, error.message));
         } else {

--- a/src/user-households/user-households.test.ts
+++ b/src/user-households/user-households.test.ts
@@ -112,6 +112,7 @@ describe('user households routes', () => {
             created_by: '',
             created_at: '2025-01-01T00:00:00Z',
             updated_at: '2025-01-01T00:00:00Z',
+            pending_invites: [],
           },
         ]);
         const response = await request(app).get('/api/v1/households').send();
@@ -125,6 +126,7 @@ describe('user households routes', () => {
             created_by: '',
             created_at: '2025-01-01T00:00:00Z',
             updated_at: '2025-01-01T00:00:00Z',
+            pending_invites: [],
           },
         ]);
       });
@@ -137,6 +139,7 @@ describe('user households routes', () => {
           created_by: '',
           created_at: '2025-01-01T00:00:00Z',
           updated_at: '2025-01-01T00:00:00Z',
+          pending_invites: [],
         });
         const response = await request(app).post('/api/v1/households').send({ name: 'Dave' });
 
@@ -149,6 +152,7 @@ describe('user households routes', () => {
           created_by: '',
           created_at: '2025-01-01T00:00:00Z',
           updated_at: '2025-01-01T00:00:00Z',
+          pending_invites: [],
         });
       });
       it('should return a 409 status code when the household already exists', async () => {
@@ -188,6 +192,7 @@ describe('user households routes', () => {
           created_by: '',
           created_at: '2025-01-01T00:00:00Z',
           updated_at: '2025-01-01T00:00:00Z',
+          pending_invites: [],
         });
         const response = await request(app).patch('/api/v1/households/1').send({ name: 'Dave' });
 
@@ -200,6 +205,7 @@ describe('user households routes', () => {
           created_by: '',
           created_at: '2025-01-01T00:00:00Z',
           updated_at: '2025-01-01T00:00:00Z',
+          pending_invites: [],
         });
       });
       it('should return a 409 status code when updating name to match an existing household', async () => {
@@ -427,6 +433,17 @@ describe('user households routes', () => {
         expect(response.body).toEqual({
           message: 'An unknown error occurred.',
           status: 500,
+        });
+      });
+      it('should respond with a 409 if the invited user is already invited', async () => {
+        inviteUserToHouseholdMock.mockRejectedValue(new DuplicateEntityError('User already invited'));
+        const response = await request(app)
+          .post('/api/v1/households/1/invitations')
+          .send([{ invited_user: 'david@foo.com' }]);
+        expect(response.status).toEqual(409);
+        expect(response.body).toEqual({
+          message: 'User already invited',
+          status: 409,
         });
       });
     });

--- a/supabase/migrations/20251201010007_create_households_table.sql
+++ b/supabase/migrations/20251201010007_create_households_table.sql
@@ -16,26 +16,26 @@ DROP POLICY IF EXISTS "Users can view own households" ON user_service.households
 CREATE POLICY "Users can view own households" ON user_service.households
     FOR SELECT TO public
     USING (
-        (SELECT auth.jwt() ->> 'sub') = created_by
+        ((SELECT auth.jwt()) ->> 'sub') = created_by
     );
 
 DROP POLICY IF EXISTS "Users can create households" ON user_service.households;
 CREATE POLICY "Users can create households" ON user_service.households
     FOR INSERT TO public
     WITH CHECK (
-        (SELECT auth.jwt() ->> 'sub') = created_by
+        ((SELECT auth.jwt()) ->> 'sub') = created_by
     );
 
 DROP POLICY IF EXISTS "Users can delete own households" ON user_service.households;
 CREATE POLICY "Users can delete own households" ON user_service.households
     FOR DELETE TO public
     USING (
-        (SELECT auth.jwt() ->> 'sub') = created_by
+        ((SELECT auth.jwt()) ->> 'sub') = created_by
     );
 
 DROP POLICY IF EXISTS "Users can update own households" ON user_service.households;
 CREATE POLICY "Users can update own households" ON user_service.households
     FOR UPDATE TO public
     USING (
-        (SELECT auth.jwt() ->> 'sub') = created_by
+        ((SELECT auth.jwt()) ->> 'sub') = created_by
     );

--- a/supabase/migrations/20251203214308_create_household_invitations_table.sql
+++ b/supabase/migrations/20251203214308_create_household_invitations_table.sql
@@ -24,9 +24,9 @@ DROP POLICY IF EXISTS "Users can create invitations for households they own" ON 
 CREATE POLICY "Users can create invitations for households they own" ON user_service.household_invitations
     FOR INSERT TO public
     WITH CHECK (
-    (SELECT auth.jwt() ->> 'sub') = (SELECT created_by
-                                     from user_service.households
-                                     WHERE id = household_id)
+    ((SELECT auth.jwt()) ->> 'sub') = (SELECT created_by
+                                       from user_service.households
+                                       WHERE id = household_id)
     );
 
 DROP POLICY IF EXISTS "Users can delete own invitations" ON user_service.household_invitations;


### PR DESCRIPTION
- Extend household responses to include `pending_invites` field.
- Implement `addPendingInvitations` method in the service to populate pending invites for households.
- Handle `DuplicateEntityError` for duplicate invitations with a 409 status code.
- Update OpenAPI spec to document `pending_invites` in household schema.
- Enhance test coverage for pending invites and duplicate invitation scenarios.