### PR TITLE
Add `updated_at` trigger for households and enhance service methods

### DIFF
--- a/src/user-households/user-households-service.db.test.ts
+++ b/src/user-households/user-households-service.db.test.ts
@@ -67,7 +67,7 @@ describe('user households service', () => {
   it('should be possible to update an existing household created by the user making the request', async () => {
     const household = await serviceA.createHousehold({ name: 'A' });
     const updatedHousehold = await serviceA.updateHousehold(household.id, { name: 'B' });
-    expect(updatedHousehold).toEqual({ ...household, name: 'B' });
+    expect(updatedHousehold).toEqual({ ...household, updated_at: updatedHousehold.updated_at, name: 'B' });
     expect(await serviceA.getUserHouseholds()).toEqual([expect.objectContaining({ name: 'B' })]);
   });
   it('should not be possible to update a household created by another user', async () => {
@@ -144,5 +144,10 @@ describe('user households service', () => {
         pending_invites: [expect.objectContaining({ invited_user: 'B', household_id: id, invited_by_user_id: 'A' })],
       }),
     );
+  });
+  it('should update the updated_at time on patch', async () => {
+    const { id, updated_at } = await serviceA.createHousehold({ name: 'A' });
+    const { updated_at: new_updated_at } = await serviceA.updateHousehold(id, { name: 'C' });
+    expect(updated_at).not.toEqual(new_updated_at);
   });
 });

--- a/supabase/migrations/20251218010253_edit_household_last_updated_at_trigger.sql
+++ b/supabase/migrations/20251218010253_edit_household_last_updated_at_trigger.sql
@@ -1,0 +1,6 @@
+create extension if not exists moddatetime schema user_service;
+create trigger handle_updated_at
+    before update
+    on user_service.households
+    for each row
+execute procedure user_service.moddatetime(updated_at);


### PR DESCRIPTION
- Add a database trigger to automatically update the `updated_at` field for the `households` table on updates.
- Introduce `WritableHousehold` type for easier management of writable fields in the service.
- Update `createHousehold` and `updateHousehold` methods to use `WritableHousehold`.
- Adjust tests to validate `updated_at` changes and ensure correctness.