### PR TITLE
feat: enable acceptance of household invitations (#29)

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="postgres@aws-1-eu-central-1.pooler.supabase.com" uuid="75c7afe4-ca52-4db1-9fad-17f0f0cda126">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://aws-1-eu-central-1.pooler.supabase.com:5432/postgres</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourcePerFileMappings">
+    <file url="file://$PROJECT_DIR$/supabase/migrations/20260113204314_accept_invitation.sql" value="75c7afe4-ca52-4db1-9fad-17f0f0cda126" />
+  </component>
+</project>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/supabase/migrations/20260113204314_accept_invitation.sql" dialect="PostgreSQL" />
+  </component>
+</project>

--- a/api-spec/openapi.yml
+++ b/api-spec/openapi.yml
@@ -210,6 +210,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /invitations/{invitationId}/accept:
+    post:
+      tags:
+        - households
+      summary: accept an invitation to join a household
+      description: accept an invitation to join a household
+      operationId: acceptHouseholdInvitation
+      parameters:
+        - in: path
+          name: invitationId
+          schema:
+            type: integer
+          required: true
+      responses:
+        204:
+          description: success
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     BaseUser:
@@ -261,14 +283,11 @@ components:
       required:
         - id
         - user_id
-        - role
         - joined_at
       properties:
         id:
           type: integer
         user_id:
-          type: string
-        role:
           type: string
         joined_at:
           type: string
@@ -282,6 +301,7 @@ components:
         - created_by
         - updated_at
         - pending_invites
+        - members
       properties:
         id:
           type: integer

--- a/src/db-error-handling/supabase-errors.ts
+++ b/src/db-error-handling/supabase-errors.ts
@@ -19,3 +19,9 @@ export class NotFoundError extends Error {
     super(message);
   }
 }
+
+export class ForbiddenError extends Error {
+  constructor(message = 'Forbidden') {
+    super(message);
+  }
+}

--- a/src/routes/user-invitations-router.ts
+++ b/src/routes/user-invitations-router.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import createError from 'http-errors';
+import { ForbiddenError, NotFoundError } from '../db-error-handling/supabase-errors.js';
 import { UserHouseholdsService } from '../user-households/user-households-service.js';
 
 const router = Router();
@@ -22,4 +23,28 @@ router.delete('/:invitationId', async (request, response, next) => {
     next(createError(401, 'Invalid credentials'));
   }
 });
+
+router.post('/:invitationId/accept', async (request, response, next) => {
+  const userId = request.auth?.payload.email as string;
+  if (userId) {
+    const householdService = new UserHouseholdsService(userId);
+    try {
+      await householdService.acceptInvitation(Number(request.params.invitationId));
+      response.status(204).end();
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        next(createError(404, error.message));
+      } else if (error instanceof ForbiddenError) {
+        next(createError(403, error.message));
+      } else if (error instanceof Error) {
+        next(createError(500, error.message));
+      } else {
+        next(createError(500, 'An unknown error occurred.'));
+      }
+    }
+  } else {
+    next(createError(401, 'Invalid credentials'));
+  }
+});
+
 export default router;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -40,6 +40,35 @@ export type Database = {
           },
         ];
       };
+      household_members: {
+        Row: {
+          household_id: number;
+          id: number;
+          joined_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          household_id: number;
+          id?: number;
+          joined_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          household_id?: number;
+          id?: number;
+          joined_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'household_members_household_id_fkey';
+            columns: ['household_id'];
+            isOneToOne: false;
+            referencedRelation: 'households';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       households: {
         Row: {
           created_at: string | null;
@@ -69,7 +98,8 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      is_household_member: { Args: { h_id: number }; Returns: boolean };
+      is_household_owner: { Args: { household_id: number }; Returns: boolean };
     };
     Enums: {
       [_ in never]: never;

--- a/supabase/migrations/20251201010007_create_households_table.sql
+++ b/supabase/migrations/20251201010007_create_households_table.sql
@@ -12,13 +12,6 @@ CREATE INDEX IF NOT EXISTS idx_households_created_by ON user_service.households 
 ALTER TABLE user_service.households
     ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "Users can view own households" ON user_service.households;
-CREATE POLICY "Users can view own households" ON user_service.households
-    FOR SELECT TO public
-    USING (
-        ((SELECT auth.jwt()) ->> 'sub') = created_by
-    );
-
 DROP POLICY IF EXISTS "Users can create households" ON user_service.households;
 CREATE POLICY "Users can create households" ON user_service.households
     FOR INSERT TO public

--- a/supabase/migrations/20260113204314_accept_invitation.sql
+++ b/supabase/migrations/20260113204314_accept_invitation.sql
@@ -1,0 +1,98 @@
+CREATE TABLE IF NOT EXISTS user_service.household_members
+(
+    id           SERIAL PRIMARY KEY,
+    household_id INTEGER NOT NULL REFERENCES user_service.households (id) ON DELETE CASCADE,
+    user_id      TEXT    NOT NULL,
+    joined_at    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (household_id, user_id)
+);
+
+ALTER TABLE user_service.household_members
+    ENABLE ROW LEVEL SECURITY;
+
+-- Function to check if user is owner, bypassing RLS
+CREATE OR REPLACE FUNCTION user_service.is_household_owner(household_id INTEGER)
+    RETURNS BOOLEAN AS
+$$
+BEGIN
+    RETURN EXISTS (SELECT 1
+                   FROM user_service.households
+                   WHERE id = household_id
+                     AND created_by = ((SELECT auth.jwt()) ->> 'sub'));
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Function to check if user is member, bypassing RLS
+CREATE OR REPLACE FUNCTION user_service.is_household_member(h_id INTEGER)
+    RETURNS BOOLEAN AS
+$$
+BEGIN
+    RETURN EXISTS (SELECT 1
+                   FROM user_service.household_members m
+                   WHERE m.household_id = h_id
+                     AND m.user_id = ((SELECT auth.jwt()) ->> 'sub'));
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION user_service.add_owner_as_member()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO user_service.household_members (household_id, user_id)
+    VALUES (NEW.id, NEW.created_by);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS on_household_created ON user_service.households;
+CREATE TRIGGER on_household_created
+    AFTER INSERT
+    ON user_service.households
+    FOR EACH ROW
+EXECUTE FUNCTION user_service.add_owner_as_member();
+
+DROP POLICY IF EXISTS "Users can view their own invitations" ON user_service.household_invitations;
+CREATE POLICY "Users can view their own invitations" ON user_service.household_invitations
+    FOR SELECT TO public
+    USING (
+    ((SELECT auth.jwt()) ->> 'sub') = invited_user
+    );
+
+DROP POLICY IF EXISTS "Users can view invitations for households they own" ON user_service.household_invitations;
+CREATE POLICY "Users can view invitations for households they own" ON user_service.household_invitations
+    FOR SELECT TO public
+    USING (
+    user_service.is_household_owner(household_id)
+    );
+DROP POLICY IF EXISTS "Users can view members of households they own" ON user_service.household_members;
+CREATE POLICY "Users can view members of households they own" ON user_service.household_members
+    FOR SELECT TO public
+    USING (
+    user_service.is_household_owner(household_id)
+    );
+DROP POLICY IF EXISTS "User can view their own household memberships" ON user_service.household_members;
+CREATE POLICY "User can view their own household memberships" ON user_service.household_members
+    FOR SELECT TO public
+    USING (
+    user_id = ((SELECT auth.jwt()) ->> 'sub')
+    );
+
+DROP POLICY IF EXISTS "Users can view households they created" ON user_service.households;
+CREATE POLICY "Users can view households they created" ON user_service.households
+    FOR SELECT TO public
+    USING (
+    created_by = ((SELECT auth.jwt()) ->> 'sub')
+    );
+DROP POLICY IF EXISTS "Users can view households they are members of" ON user_service.households;
+CREATE POLICY "Users can view households they are members of" ON user_service.households
+    FOR SELECT TO public
+    USING (
+    user_service.is_household_member(id)
+    );
+
+DROP POLICY IF EXISTS "Users can join households" ON user_service.household_members;
+CREATE POLICY "Users can join households" ON user_service.household_members
+    FOR INSERT TO public
+    WITH CHECK (
+    user_id = ((SELECT auth.jwt()) ->> 'sub')
+    );


### PR DESCRIPTION
Introduce functionality for accepting household invitations, adding the user as a member and removing the invitation upon acceptance. Update API routes, database policies, and Supabase schema to support this feature. Enhance tests and OpenAPI spec to ensure proper behavior and documentation.