### PR TITLE
feat: add token exchange and public key endpoints

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -1,0 +1,14 @@
+System Context & Architectural Blueprint: Multi-Tenant MFE with Postgres RLS
+Architecture Overview:
+Data Isolation: Enforced via PostgreSQL Row-Level Security (RLS) using a session variable app.current_household_id.
+Identity: Auth0 serves as the primary Identity Provider (Global User JWT).
+Context: A custom UserService (Express/Node.js) manages Household memberships.
+Token Flow: The Micro-frontend (MFE) performs a Direct Exchange. It sends the Auth0 JWT + a household_id to the UserService/exchange endpoint, which returns a short-lived Internal JWT signed by the UserService.
+MFE Integration: Hybrid Approach. The Wrapper UI (Host) manages the URL (e.g., /household/:id/mfe) and passes the household_id to the MFE (Remote) via a React Prop.
+Backend Enforcement: Micro-service backends receive the Internal JWT, verify the signature, and inject the household_id into the Postgres transaction using SET LOCAL.
+Implementation Requirements needed:
+Postgres Schema: Provide DDL and RLS policies for a multi-tenant table. Use ALTER TABLE ... FORCE ROW LEVEL SECURITY. The policy must use current_setting('app.current_household_id'). Include indexing strategies for the tenant column.
+MFE Token Manager: Implement a utility in [Insert Framework, e.g., Vite/React] that manages the direct exchange. It must include Request Collapsing (using a Promise-based cache) to ensure multiple components triggering getInternalToken() simultaneously only result in one call to the UserService.
+Backend Context Wrapper: Implement a database interceptor in [Insert Language/Framework, e.g., Spring Boot/Java or Express/Node] that extracts the household_id from the Internal JWT and executes the SET LOCAL command within a transaction to ensure RLS is applied.
+Standalone Dev Mode: Show how the MFE can detect it is running without the Wrapper, provide its own Auth0 login, and a "Dev Toolbar" to manually set the householdId prop for testing the exchange logic locally.
+UserService Exchange Logic: Provide an Express endpoint that validates an Auth0 JWT, verifies the user belongs to the requested household_id in the database, and issues the signed Internal JWT.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+TODO
+
 ### Node template
 # Logs
 logs

--- a/api-spec/openapi.yml
+++ b/api-spec/openapi.yml
@@ -232,6 +232,94 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /members/{memberId}:
+    delete:
+      tags:
+        - households
+      summary: remove a member from a household
+      description: remove a member from a household
+      operationId: removeHouseholdMember
+      parameters:
+        - in: path
+          name: memberId
+          schema:
+            type: integer
+          required: true
+      responses:
+        204:
+          description: success
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /token/exchange:
+    post:
+      tags:
+        - token
+      summary: Exchange Auth0 JWT for internal household-scoped JWT
+      description: Exchange Auth0 JWT for internal household-scoped JWT
+      operationId: exchangeToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - household_id
+              properties:
+                household_id:
+                  type: integer
+                audience:
+                  type: string
+                  default: internal
+                  description: The target audience for the generated JWT. Defaults to 'internal'.
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - token
+                properties:
+                  token:
+                    type: string
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /token/public-key:
+    get:
+      tags:
+        - token
+      summary: Get public key for verifying internal JWTs
+      description: Get the RSA public key that microservices should use to verify internal JWT signatures
+      operationId: getPublicKey
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - publicKey
+                properties:
+                  publicKey:
+                    type: string
+                    description: PEM-encoded RSA public key
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     BaseUser:

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { generalErrorHandler, notFoundHandler } from './error-handler.js';
 import householdsRouter from './routes/user-households-router.js';
 import userInfoRouter from './routes/user-info-router.js';
 import invitationsRouter from './routes/user-invitations-router.js';
+import tokenExchangeRouter from './routes/token-exchange-router.js';
 
 const jwtCheck = auth({
   audience: 'https://user-service.dajohnston.co.uk',
@@ -47,6 +48,7 @@ app.use(
 app.use('/api/v1/user-info', userInfoRouter);
 app.use('/api/v1/households', householdsRouter);
 app.use('/api/v1/invitations', invitationsRouter);
+app.use('/api/v1/token', tokenExchangeRouter);
 // Error handlers
 app.use(generalErrorHandler, notFoundHandler);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,10 @@ import OpenApiValidator from 'express-openapi-validator';
 import logger from 'morgan';
 
 import { generalErrorHandler, notFoundHandler } from './error-handler.js';
+import tokenExchangeRouter from './routes/token-exchange-router.js';
 import householdsRouter from './routes/user-households-router.js';
 import userInfoRouter from './routes/user-info-router.js';
 import invitationsRouter from './routes/user-invitations-router.js';
-import tokenExchangeRouter from './routes/token-exchange-router.js';
 
 const jwtCheck = auth({
   audience: 'https://user-service.dajohnston.co.uk',

--- a/src/routes/token-exchange-router.ts
+++ b/src/routes/token-exchange-router.ts
@@ -1,0 +1,47 @@
+import { Router } from 'express';
+import createError from 'http-errors';
+import { TokenExchangeService } from '../token-exchange/token-exchange-service.js';
+import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
+
+const router = Router();
+
+router.post('/exchange', async (request, response, next) => {
+  const userId = request.auth?.payload.email as string;
+  if (!userId) {
+    return next(createError(401, 'Invalid credentials'));
+  }
+
+  const { household_id, audience } = request.body;
+  if (!household_id) {
+    return next(createError(400, 'household_id is required'));
+  }
+
+  try {
+    const tokenService = new TokenExchangeService(userId);
+    const token = await tokenService.exchangeToken(household_id, audience);
+    response.status(200).json({ token });
+  } catch (error: unknown) {
+    if (error instanceof ForbiddenError) {
+      next(createError(403, error.message));
+    } else if (error instanceof Error) {
+      next(createError(500, error.message));
+    } else {
+      next(createError(500, 'An unknown error occurred.'));
+    }
+  }
+});
+
+router.get('/public-key', (request, response, next) => {
+  try {
+    const publicKey = TokenExchangeService.getPublicKey();
+    response.status(200).json({ publicKey });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      next(createError(500, error.message));
+    } else {
+      next(createError(500, 'An unknown error occurred.'));
+    }
+  }
+});
+
+export default router;

--- a/src/routes/token-exchange-router.ts
+++ b/src/routes/token-exchange-router.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import createError from 'http-errors';
-import { TokenExchangeService } from '../token-exchange/token-exchange-service.js';
 import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
+import { TokenExchangeService } from '../token-exchange/token-exchange-service.js';
 
 const router = Router();
 
@@ -31,7 +31,7 @@ router.post('/exchange', async (request, response, next) => {
   }
 });
 
-router.get('/public-key', (request, response, next) => {
+router.get('/public-key', (_request, response, next) => {
   try {
     const publicKey = TokenExchangeService.getPublicKey();
     response.status(200).json({ publicKey });

--- a/src/token-exchange/token-exchange-service.test.ts
+++ b/src/token-exchange/token-exchange-service.test.ts
@@ -1,0 +1,71 @@
+import { decodeJwt, exportPKCS8, generateKeyPair } from 'jose';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserHouseholdsService } from '../user-households/user-households-service.js';
+import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
+import { TokenExchangeService } from './token-exchange-service.js';
+
+vi.mock('../user-households/user-households-service.js');
+
+describe('TokenExchangeService', () => {
+  const mockUser = 'test-user@example.com';
+  let privateKey: string;
+
+  beforeEach(async () => {
+    const keys = await generateKeyPair('RS256', { extractable: true });
+    privateKey = await exportPKCS8(keys.privateKey);
+    vi.stubEnv('INTERNAL_JWT_PRIVATE_KEY', privateKey);
+    vi.stubEnv('INTERNAL_JWT_PUBLIC_KEY', 'dummy-public-key');
+  });
+
+  it('should use "internal" as audience if none provided', async () => {
+    const householdId = 123;
+    vi.mocked(UserHouseholdsService).prototype.getUserHouseholds.mockResolvedValue([{ id: householdId } as any]);
+
+    const service = new TokenExchangeService(mockUser);
+    const token = await service.exchangeToken(householdId);
+
+    const decoded = decodeJwt(token);
+    expect(decoded.aud).toBe('internal');
+  });
+
+  it('should use provided audience', async () => {
+    const householdId = 123;
+    vi.mocked(UserHouseholdsService).prototype.getUserHouseholds.mockResolvedValue([{ id: householdId } as any]);
+
+    const service = new TokenExchangeService(mockUser);
+    const token = await service.exchangeToken(householdId, 'custom-audience');
+
+    const decoded = decodeJwt(token);
+    expect(decoded.aud).toBe('custom-audience');
+  });
+
+  it('should throw error if user does not have access to household', async () => {
+    const householdId = 123;
+    vi.mocked(UserHouseholdsService).prototype.getUserHouseholds.mockResolvedValue([{ id: 456 } as any]);
+
+    const service = new TokenExchangeService(mockUser);
+    await expect(service.exchangeToken(householdId)).rejects.toThrow(ForbiddenError);
+    await expect(service.exchangeToken(householdId)).rejects.toThrow('User does not have access to this household');
+  });
+
+  it('should throw error if private key is not set', async () => {
+    const householdId = 123;
+    vi.mocked(UserHouseholdsService).prototype.getUserHouseholds.mockResolvedValue([{ id: householdId } as any]);
+    vi.stubEnv('INTERNAL_JWT_PRIVATE_KEY', '');
+
+    const service = new TokenExchangeService(mockUser);
+    await expect(service.exchangeToken(householdId)).rejects.toThrow('INTERNAL_JWT_PRIVATE_KEY environment variable not set');
+  });
+
+  describe('getPublicKey', () => {
+    it('should return the public key from env', () => {
+      vi.stubEnv('INTERNAL_JWT_PUBLIC_KEY', 'test-public-key');
+      expect(TokenExchangeService.getPublicKey()).toBe('test-public-key');
+    });
+
+    it('should throw error if public key is not set', () => {
+      vi.stubEnv('INTERNAL_JWT_PUBLIC_KEY', '');
+      expect(() => TokenExchangeService.getPublicKey()).toThrow('INTERNAL_JWT_PUBLIC_KEY environment variable not set');
+    });
+  });
+});

--- a/src/token-exchange/token-exchange-service.ts
+++ b/src/token-exchange/token-exchange-service.ts
@@ -1,0 +1,50 @@
+import { importPKCS8, SignJWT } from 'jose';
+import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
+import { UserHouseholdsService } from '../user-households/user-households-service.js';
+
+export class TokenExchangeService {
+  private readonly user: string;
+
+  constructor(user: string) {
+    this.user = user;
+  }
+
+  async exchangeToken(householdId: number, audience = 'internal'): Promise<string> {
+    // Verify user has access to this household
+    const householdService = new UserHouseholdsService(this.user);
+    const households = await householdService.getUserHouseholds();
+
+    const hasAccess = households.some((h) => h.id === householdId);
+    if (!hasAccess) {
+      throw new ForbiddenError('User does not have access to this household');
+    }
+
+    // Load the private key for signing
+    const privateKeyPem = process.env.INTERNAL_JWT_PRIVATE_KEY;
+    if (!privateKeyPem) {
+      throw new Error('INTERNAL_JWT_PRIVATE_KEY environment variable not set');
+    }
+
+    const privateKey = await importPKCS8(privateKeyPem, 'RS256');
+
+    // Generate internal JWT with household_id claim
+    return await new SignJWT({
+      email: this.user,
+      household_id: householdId,
+    })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuedAt()
+      .setIssuer('user-service')
+      .setAudience(audience)
+      .setExpirationTime('15m')
+      .sign(privateKey);
+  }
+
+  static getPublicKey(): string {
+    const publicKey = process.env.INTERNAL_JWT_PUBLIC_KEY;
+    if (!publicKey) {
+      throw new Error('INTERNAL_JWT_PUBLIC_KEY environment variable not set');
+    }
+    return publicKey;
+  }
+}

--- a/src/token-exchange/token-exchange.test.ts
+++ b/src/token-exchange/token-exchange.test.ts
@@ -1,0 +1,159 @@
+import type { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import app from '../index.js';
+import { TokenExchangeService } from './token-exchange-service.js';
+import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
+
+const authMiddleware = vi.hoisted(() => vi.fn());
+
+vi.mock('express-oauth2-jwt-bearer', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('express-oauth2-jwt-bearer')>()),
+  auth: vi.fn().mockReturnValue(authMiddleware),
+}));
+
+vi.mock('./token-exchange-service.js');
+
+describe('token exchange router', () => {
+  beforeEach(() => {
+    authMiddleware.mockImplementation((request: Request, _response: Response, next: NextFunction) => {
+      request.auth = {
+        header: {},
+        payload: {
+          email: 'test@example.com',
+        },
+        token: '',
+      };
+      next();
+    });
+  });
+
+  it('should pass audience to TokenExchangeService', async () => {
+    const exchangeTokenMock = vi.fn().mockResolvedValue('fake-token');
+    vi.mocked(TokenExchangeService).prototype.exchangeToken = exchangeTokenMock;
+
+    const response = await request(app)
+      .post('/api/v1/token/exchange')
+      .send({ household_id: 1, audience: 'custom-aud' });
+
+    expect(response.status).toBe(200);
+    expect(exchangeTokenMock).toHaveBeenCalledWith(1, 'custom-aud');
+  });
+
+  it('should use default audience from OpenAPI spec if not provided', async () => {
+    const exchangeTokenMock = vi.fn().mockResolvedValue('fake-token');
+    vi.mocked(TokenExchangeService).prototype.exchangeToken = exchangeTokenMock;
+
+    const response = await request(app)
+      .post('/api/v1/token/exchange')
+      .send({ household_id: 1 });
+
+    expect(response.status).toBe(200);
+    expect(exchangeTokenMock).toHaveBeenCalledWith(1, 'internal');
+  });
+
+  describe('error handling', () => {
+    it('should return 401 if user is not authenticated', async () => {
+      authMiddleware.mockImplementation((request: Request, _response: Response, next: NextFunction) => {
+        request.auth = undefined;
+        next();
+      });
+
+      const response = await request(app)
+        .post('/api/v1/token/exchange')
+        .send({ household_id: 1 });
+
+      expect(response.status).toBe(401);
+      expect(response.body.message).toBe('Invalid credentials');
+    });
+
+    it('should return 400 if household_id is missing', async () => {
+      const response = await request(app)
+        .post('/api/v1/token/exchange')
+        .send({});
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 if household_id is 0 (falsy)', async () => {
+      const response = await request(app)
+        .post('/api/v1/token/exchange')
+        .send({ household_id: 0 });
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('household_id is required');
+    });
+
+    it('should return 403 if user does not have access', async () => {
+      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi.fn().mockRejectedValue(new ForbiddenError('User does not have access to this household'));
+
+      const response = await request(app)
+        .post('/api/v1/token/exchange')
+        .send({ household_id: 1 });
+
+      expect(response.status).toBe(403);
+      expect(response.body.message).toBe('User does not have access to this household');
+    });
+
+    it('should return 500 for other Error instances', async () => {
+      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi.fn().mockRejectedValue(new Error('Some other error'));
+
+      const response = await request(app)
+        .post('/api/v1/token/exchange')
+        .send({ household_id: 1 });
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe('Some other error');
+    });
+
+    it('should return 500 for non-Error exceptions', async () => {
+      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi.fn().mockRejectedValue('not an error object');
+
+      const response = await request(app)
+        .post('/api/v1/token/exchange')
+        .send({ household_id: 1 });
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe('An unknown error occurred.');
+    });
+  });
+
+  describe('GET /public-key', () => {
+    it('should return the public key', async () => {
+      vi.mocked(TokenExchangeService.getPublicKey).mockReturnValue('test-public-key');
+
+      const response = await request(app)
+        .get('/api/v1/token/public-key')
+        .send();
+
+      expect(response.status).toBe(200);
+      expect(response.body.publicKey).toBe('test-public-key');
+    });
+
+    it('should return 500 if public key is not set', async () => {
+      vi.mocked(TokenExchangeService.getPublicKey).mockImplementation(() => {
+        throw new Error('INTERNAL_JWT_PUBLIC_KEY environment variable not set');
+      });
+
+      const response = await request(app)
+        .get('/api/v1/token/public-key')
+        .send();
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe('INTERNAL_JWT_PUBLIC_KEY environment variable not set');
+    });
+
+    it('should return 500 for non-Error exceptions in public-key', async () => {
+      vi.mocked(TokenExchangeService.getPublicKey).mockImplementation(() => {
+        throw 'not an error object';
+      });
+
+      const response = await request(app)
+        .get('/api/v1/token/public-key')
+        .send();
+
+      expect(response.status).toBe(500);
+      expect(response.body.message).toBe('An unknown error occurred.');
+    });
+  });
+});

--- a/src/token-exchange/token-exchange.test.ts
+++ b/src/token-exchange/token-exchange.test.ts
@@ -1,9 +1,9 @@
 import type { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
 import app from '../index.js';
 import { TokenExchangeService } from './token-exchange-service.js';
-import { ForbiddenError } from '../db-error-handling/supabase-errors.js';
 
 const authMiddleware = vi.hoisted(() => vi.fn());
 
@@ -44,9 +44,7 @@ describe('token exchange router', () => {
     const exchangeTokenMock = vi.fn().mockResolvedValue('fake-token');
     vi.mocked(TokenExchangeService).prototype.exchangeToken = exchangeTokenMock;
 
-    const response = await request(app)
-      .post('/api/v1/token/exchange')
-      .send({ household_id: 1 });
+    const response = await request(app).post('/api/v1/token/exchange').send({ household_id: 1 });
 
     expect(response.status).toBe(200);
     expect(exchangeTokenMock).toHaveBeenCalledWith(1, 'internal');
@@ -59,48 +57,42 @@ describe('token exchange router', () => {
         next();
       });
 
-      const response = await request(app)
-        .post('/api/v1/token/exchange')
-        .send({ household_id: 1 });
+      const response = await request(app).post('/api/v1/token/exchange').send({ household_id: 1 });
 
       expect(response.status).toBe(401);
       expect(response.body.message).toBe('Invalid credentials');
     });
 
     it('should return 400 if household_id is missing', async () => {
-      const response = await request(app)
-        .post('/api/v1/token/exchange')
-        .send({});
+      const response = await request(app).post('/api/v1/token/exchange').send({});
 
       expect(response.status).toBe(400);
     });
 
     it('should return 400 if household_id is 0 (falsy)', async () => {
-      const response = await request(app)
-        .post('/api/v1/token/exchange')
-        .send({ household_id: 0 });
+      const response = await request(app).post('/api/v1/token/exchange').send({ household_id: 0 });
 
       expect(response.status).toBe(400);
       expect(response.body.message).toBe('household_id is required');
     });
 
     it('should return 403 if user does not have access', async () => {
-      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi.fn().mockRejectedValue(new ForbiddenError('User does not have access to this household'));
+      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi
+        .fn()
+        .mockRejectedValue(new ForbiddenError('User does not have access to this household'));
 
-      const response = await request(app)
-        .post('/api/v1/token/exchange')
-        .send({ household_id: 1 });
+      const response = await request(app).post('/api/v1/token/exchange').send({ household_id: 1 });
 
       expect(response.status).toBe(403);
       expect(response.body.message).toBe('User does not have access to this household');
     });
 
     it('should return 500 for other Error instances', async () => {
-      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi.fn().mockRejectedValue(new Error('Some other error'));
+      vi.mocked(TokenExchangeService).prototype.exchangeToken = vi
+        .fn()
+        .mockRejectedValue(new Error('Some other error'));
 
-      const response = await request(app)
-        .post('/api/v1/token/exchange')
-        .send({ household_id: 1 });
+      const response = await request(app).post('/api/v1/token/exchange').send({ household_id: 1 });
 
       expect(response.status).toBe(500);
       expect(response.body.message).toBe('Some other error');
@@ -109,9 +101,7 @@ describe('token exchange router', () => {
     it('should return 500 for non-Error exceptions', async () => {
       vi.mocked(TokenExchangeService).prototype.exchangeToken = vi.fn().mockRejectedValue('not an error object');
 
-      const response = await request(app)
-        .post('/api/v1/token/exchange')
-        .send({ household_id: 1 });
+      const response = await request(app).post('/api/v1/token/exchange').send({ household_id: 1 });
 
       expect(response.status).toBe(500);
       expect(response.body.message).toBe('An unknown error occurred.');
@@ -122,9 +112,7 @@ describe('token exchange router', () => {
     it('should return the public key', async () => {
       vi.mocked(TokenExchangeService.getPublicKey).mockReturnValue('test-public-key');
 
-      const response = await request(app)
-        .get('/api/v1/token/public-key')
-        .send();
+      const response = await request(app).get('/api/v1/token/public-key').send();
 
       expect(response.status).toBe(200);
       expect(response.body.publicKey).toBe('test-public-key');
@@ -135,9 +123,7 @@ describe('token exchange router', () => {
         throw new Error('INTERNAL_JWT_PUBLIC_KEY environment variable not set');
       });
 
-      const response = await request(app)
-        .get('/api/v1/token/public-key')
-        .send();
+      const response = await request(app).get('/api/v1/token/public-key').send();
 
       expect(response.status).toBe(500);
       expect(response.body.message).toBe('INTERNAL_JWT_PUBLIC_KEY environment variable not set');
@@ -148,9 +134,7 @@ describe('token exchange router', () => {
         throw 'not an error object';
       });
 
-      const response = await request(app)
-        .get('/api/v1/token/public-key')
-        .send();
+      const response = await request(app).get('/api/v1/token/public-key').send();
 
       expect(response.status).toBe(500);
       expect(response.body.message).toBe('An unknown error occurred.');

--- a/src/user-households/user-households-service.db.test.ts
+++ b/src/user-households/user-households-service.db.test.ts
@@ -209,4 +209,4 @@ describe('user households service', () => {
   it('should throw an error if the invitation does not exist', async () => {
     await expect(serviceA.acceptInvitation(99999)).rejects.toThrowError('Invitation with id 99999 not found');
   });
-});
+}, 20000);

--- a/supabase/migrations/20260113234912_remove_member.sql
+++ b/supabase/migrations/20260113234912_remove_member.sql
@@ -1,0 +1,12 @@
+DROP POLICY IF EXISTS "Users can remove their own membership" ON user_service.household_members;
+CREATE POLICY "Users can remove their own membership" ON user_service.household_members
+    FOR DELETE TO public
+    USING (
+    ((SELECT auth.jwt()) ->> 'sub') = user_id
+    );
+DROP POLICY IF EXISTS "Users can remove members from households they created" ON user_service.household_members;
+CREATE POLICY "Users can remove members from households they created" ON user_service.household_members
+    FOR DELETE TO public
+    USING (
+    user_service.is_household_owner(household_id)
+    );


### PR DESCRIPTION
Introduce token exchange functionality allowing users to exchange Auth0 JWTs for internal household-scoped JWTs. Add `/token/exchange` and `/token/public-key` endpoints to enable this feature.

Update services, routes, and OpenAPI spec to support secure and audience-configurable token handling. Add comprehensive tests to ensure expected behavior and error handling.