### PR TITLE
feat: add invitation handling to household creation

### DIFF
--- a/api-spec/openapi.yml
+++ b/api-spec/openapi.yml
@@ -422,6 +422,12 @@ components:
           readOnly: true
           items:
             $ref: '#/components/schemas/HouseholdMember'
+        invitations:
+          type: array
+          items:
+            type: string
+            format: email
+          writeOnly: true
     Household:
       type: object
       allOf:

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,22 @@
-import { Pool } from '@neondatabase/serverless';
+import { Pool, type PoolClient } from '@neondatabase/serverless';
 
-const pool = new Pool({
+export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
 export const query = async (text: string, params?: (string | number)[]) => pool.query(text, params);
+
+export const withTransaction = async <T>(callback: (client: PoolClient) => Promise<T>): Promise<T> => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await callback(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/src/routes/user-households-router.ts
+++ b/src/routes/user-households-router.ts
@@ -30,6 +30,8 @@ router.post('/', async (request, response, next) => {
     } catch (error: unknown) {
       if (error instanceof DuplicateEntityError) {
         next(createError(409, error.message));
+      } else if (error instanceof InvitedUserIsOwnerError) {
+        next(createError(400, error.message));
       } else if (error instanceof Error) {
         next(createError(500, error.message));
       } else {

--- a/src/user-households/user-households-service.db.test.ts
+++ b/src/user-households/user-households-service.db.test.ts
@@ -266,7 +266,7 @@ describe('user households service', () => {
     await serviceC.acceptInvitation(invitations[1].id);
     const { members } = await serviceA.getHousehold(household_id);
     await expect(
-      serviceC.removeMember(household_id, members.find((member) => member.user_id === 'B').id),
+      serviceC.removeMember(household_id, members.find((member) => member.user_id === 'B')?.id ?? -1),
     ).rejects.toThrowError('Only the household creator or the member themselves can remove a member');
   });
   it('should delete the member if the user is the creator', async () => {
@@ -274,7 +274,7 @@ describe('user households service', () => {
     const invitations = await serviceA.inviteUsers(household_id, ['B']);
     await serviceB.acceptInvitation(invitations[0].id);
     const { members } = await serviceA.getHousehold(household_id);
-    await serviceA.removeMember(household_id, members.find((member) => member.user_id === 'B').id);
+    await serviceA.removeMember(household_id, members.find((member) => member.user_id === 'B')?.id ?? -1);
     const { members: updated_members } = await serviceA.getHousehold(household_id);
     expect(updated_members).toEqual([expect.objectContaining({ user_id: 'A' })]);
   });
@@ -283,7 +283,7 @@ describe('user households service', () => {
     const invitations = await serviceA.inviteUsers(household_id, ['B']);
     await serviceB.acceptInvitation(invitations[0].id);
     const { members } = await serviceA.getHousehold(household_id);
-    await serviceB.removeMember(household_id, members.find((member) => member.user_id === 'B').id);
+    await serviceB.removeMember(household_id, members.find((member) => member.user_id === 'B')?.id ?? -1);
     const { members: updated_members } = await serviceA.getHousehold(household_id);
     expect(updated_members).toEqual([expect.objectContaining({ user_id: 'A' })]);
   });

--- a/src/user-households/user-households-service.db.test.ts
+++ b/src/user-households/user-households-service.db.test.ts
@@ -31,6 +31,29 @@ describe('user households service', () => {
       }),
     );
   });
+  it('should invite users when creating a household', async () => {
+    const result = await serviceA.createHousehold({
+      name: 'Test Household',
+      invitations: ['B', 'C'],
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        name: 'Test Household',
+        pending_invites: [
+          expect.objectContaining({ invited_user: 'B', invited_by_user_id: 'A' }),
+          expect.objectContaining({ invited_user: 'C', invited_by_user_id: 'A' }),
+        ],
+        members: [expect.objectContaining({ user_id: 'A' })],
+      }),
+    );
+  });
+  it('should not create the household if it fails to invite the user too', async () => {
+    await expect(
+      (async () => await serviceA.createHousehold({ name: 'A', invitations: ['A'] }))(),
+    ).rejects.toThrowError('The invited user is already the owner of the household');
+    const households = await serviceA.getUserHouseholds();
+    expect(households).toEqual([]);
+  });
   it('should return only the households created by themself', async () => {
     await serviceA.createHousehold({ name: 'A' });
     await serviceB.createHousehold({ name: 'B' });

--- a/src/user-households/user-households-service.ts
+++ b/src/user-households/user-households-service.ts
@@ -1,4 +1,4 @@
-import { DatabaseError } from '@neondatabase/serverless';
+import { DatabaseError, type PoolClient } from '@neondatabase/serverless';
 import {
   DATABASE_ERROR_CODES,
   DuplicateEntityError,
@@ -6,7 +6,7 @@ import {
   InvitedUserIsOwnerError,
   NotFoundError,
 } from '../db-error-handling/db-errors.js';
-import { query } from '../lib/db.js';
+import { query, withTransaction } from '../lib/db.js';
 
 export type HouseholdMember = {
   id: number;
@@ -23,7 +23,7 @@ export type Household = {
   members?: HouseholdMember[];
   pending_invites?: HouseholdInvitation[];
 };
-export type WritableHousehold = { name: string };
+export type WritableHousehold = { name: string; invitations?: string[] };
 export type HouseholdInvitation = {
   id: number;
   household_id: number;
@@ -41,16 +41,21 @@ export class UserHouseholdsService {
 
   async createHousehold(household: WritableHousehold) {
     try {
-      const { rows } = await query(
-        'INSERT INTO user_service.households (name, created_by) VALUES ($1, $2) RETURNING *',
-        [household.name, this.user],
-      );
-      const createdHousehold = rows[0];
-      await query('INSERT INTO user_service.household_members (household_id, user_id) VALUES ($1, $2)', [
-        createdHousehold.id,
-        this.user,
-      ]);
-      return await this.enrichHousehold(createdHousehold);
+      return await withTransaction(async (client) => {
+        const { rows } = await client.query(
+          'INSERT INTO user_service.households (name, created_by) VALUES ($1, $2) RETURNING *',
+          [household.name, this.user],
+        );
+        const createdHousehold = rows[0];
+        await client.query('INSERT INTO user_service.household_members (household_id, user_id) VALUES ($1, $2)', [
+          createdHousehold.id,
+          this.user,
+        ]);
+        if (household.invitations && household.invitations.length > 0) {
+          await this.inviteUsers(createdHousehold.id, household.invitations, client);
+        }
+        return await this.enrichHousehold(createdHousehold, client);
+      });
     } catch (error) {
       throw this.handleDatabaseError(error, household);
     }
@@ -60,14 +65,15 @@ export class UserHouseholdsService {
     await query('DELETE FROM user_service.households WHERE id = $1 AND created_by = $2', [id, this.user]);
   }
 
-  async getHousehold(id: number) {
-    const { rows } = await query(
+  async getHousehold(id: number, dbClient?: PoolClient) {
+    const q = dbClient ? dbClient.query.bind(dbClient) : query;
+    const { rows } = await q(
       `SELECT * FROM user_service.households 
        WHERE id = $1 AND (created_by = $2 OR id IN (SELECT household_id FROM user_service.household_members WHERE user_id = $2))`,
       [id, this.user],
     );
     if (rows.length === 0) throw new NotFoundError(`Household with id ${id} not found`);
-    return await this.enrichHousehold(rows[0]);
+    return await this.enrichHousehold(rows[0], dbClient);
   }
 
   async updateHousehold(id: number, household: WritableHousehold) {
@@ -100,10 +106,11 @@ export class UserHouseholdsService {
     return Promise.all(rows.map(async (household) => await this.enrichHousehold(household)));
   }
 
-  async enrichHousehold(household: Household) {
+  async enrichHousehold(household: Household, dbClient?: PoolClient) {
+    const q = dbClient ? dbClient.query.bind(dbClient) : query;
     const [{ rows: pending_invites }, { rows: members }] = await Promise.all([
-      query('SELECT * FROM user_service.household_invitations WHERE household_id = $1', [household.id]),
-      query('SELECT * FROM user_service.household_members WHERE household_id = $1', [household.id]),
+      q('SELECT * FROM user_service.household_invitations WHERE household_id = $1', [household.id]),
+      q('SELECT * FROM user_service.household_members WHERE household_id = $1', [household.id]),
     ]);
 
     return {
@@ -113,13 +120,14 @@ export class UserHouseholdsService {
     };
   }
 
-  async inviteUsers(householdId: number, emails: string[]) {
-    const household = await this.getHousehold(householdId);
+  async inviteUsers(householdId: number, emails: string[], dbClient?: PoolClient) {
+    const household = await this.getHousehold(householdId, dbClient);
     if (emails.includes(household.created_by)) throw new InvitedUserIsOwnerError();
 
+    const q = dbClient ? dbClient.query.bind(dbClient) : query;
     return await Promise.all(
       emails.map(async (email) => {
-        const { rows } = await query(
+        const { rows } = await q(
           'INSERT INTO user_service.household_invitations (invited_user, household_id, invited_by_user_id) VALUES ($1, $2, $3) RETURNING *',
           [email, householdId, this.user],
         ).catch((error) => {
@@ -173,7 +181,7 @@ export class UserHouseholdsService {
 
   async removeMember(householdId: number, memberId: number) {
     const household = await this.getHousehold(householdId);
-    const member = household.members?.find((m) => m.id === memberId);
+    const member = household.members?.find((m: { id: number }) => m.id === memberId);
 
     if (!member) {
       throw new NotFoundError(`Member with id ${memberId} not found in household ${householdId}`);

--- a/src/user-households/user-households-service.ts
+++ b/src/user-households/user-households-service.ts
@@ -20,8 +20,8 @@ export type Household = {
   updated_at: string | null;
   created_at: string | null;
   created_by: string;
-  members?: HouseholdMember[];
-  pending_invites?: HouseholdInvitation[];
+  members: HouseholdMember[];
+  pending_invites: HouseholdInvitation[];
 };
 export type WritableHousehold = { name: string; invitations?: string[] };
 export type HouseholdInvitation = {
@@ -103,7 +103,7 @@ export class UserHouseholdsService {
        ORDER BY created_at DESC`,
       [this.user],
     );
-    return Promise.all(rows.map(async (household) => await this.enrichHousehold(household)));
+    return Promise.all(rows.map(async (household: Household) => await this.enrichHousehold(household)));
   }
 
   async enrichHousehold(household: Household, dbClient?: PoolClient) {
@@ -117,7 +117,7 @@ export class UserHouseholdsService {
       ...household,
       pending_invites,
       members,
-    };
+    } as Household;
   }
 
   async inviteUsers(householdId: number, emails: string[], dbClient?: PoolClient) {
@@ -136,7 +136,7 @@ export class UserHouseholdsService {
           }
           throw error;
         });
-        return rows[0];
+        return rows[0] as HouseholdInvitation;
       }),
     );
   }
@@ -166,7 +166,7 @@ export class UserHouseholdsService {
     if (rows.length === 0) {
       throw new NotFoundError(`Invitation with id ${invitationId} not found`);
     }
-    const invitation = rows[0];
+    const invitation = rows[0] as HouseholdInvitation;
 
     if (invitation.invited_user !== this.user) {
       throw new ForbiddenError('This invitation is not for you');


### PR DESCRIPTION
Introduce support for sending invitations during household creation. Modify the `createHousehold` method to accept and process email invitations using transactional database operations. Enhance error handling for invalid invitations and update OpenAPI spec to include `invitations` as a write-only field. Expand test coverage to validate proper behavior, including transactional rollback for failures.